### PR TITLE
Simplify for loop

### DIFF
--- a/content/posts/26-02-21-cpp-to-rust.md
+++ b/content/posts/26-02-21-cpp-to-rust.md
@@ -81,7 +81,7 @@ fn main() {
 
     println!("p3\n{} {}\n255", image_height, image_width);
 
-    for j in (0..=image_height - 1).into_iter().rev() {
+    for j in (0..image_height).rev() {
         for i in 0..image_width {
             let r = i as f64 / (image_width - 1) as f64;
             let g = j as f64 / (image_height - 1) as f64;


### PR DESCRIPTION
It seems a bit strange to use `=` for an inclusive range but then to subtract `1` to make it exclusive again ...

Also, the range already implements `Iterator`, so no `.into_iterator()` is needed.